### PR TITLE
RowSelectionModel:selectActiveRow is broken

### DIFF
--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -161,8 +161,8 @@
     }
 
     function handleActiveCellChange(e, data) {
-      if (_options.selectActiveRow && data.row != null) {
-        setSelectedRanges([new Slick.Range(data.row, 0, data.row, _grid.getColumns().length - 1)]);
+      if (_options.selectActiveRow && data.activeCell.row != null) {
+        setSelectedRanges([new Slick.Range(data.activeCell.row, 0, data.activeCell.row, _grid.getColumns().length - 1)]);
       }
     }
 


### PR DESCRIPTION
slick.grid.js:setActiveCellInternal() used to call

```
trigger(self.onActiveCellChanged, getActiveCell());
```

but now it calls

```
trigger(self.onActiveCellChanged, {activeCell: getActiveCell(),prevActiveCell: prevActiveCell,editMode:opt_editMode,}, e);
```

which means the data sent to slick.rowselectionmodel.js:handleActiveCellChange() has changed from

```
Object {row: 4, cell: 4, grid: SlickGrid}
```

to

```
Object {activeCell: Object, prevActiveCell: null, editMode: false, grid: SlickGrid}
```

slick.grid.js:setActiveCellInternal() is manually adding add a "active-row" CSS class to the cell's parent (i.e. the row), but the row is never actually selected in the RowSelectionModel. This patch fixes that.
